### PR TITLE
Improvements to loading script

### DIFF
--- a/terraform_create_images/modules/loader_vm/scripts/create_and_load_everything_from_scratch.sh
+++ b/terraform_create_images/modules/loader_vm/scripts/create_and_load_everything_from_scratch.sh
@@ -96,7 +96,6 @@ done
 ### lots of concurrent loading is happening. Load all the d2v2g data in first
 ### and then push everything else in behind it.
 halfCPU=$(expr $cpu_count / 2)
-quarterCPU=$(expr $cpu_count / 4)
 
 {
   echo "--- D2V2G SCORED START ---"

--- a/terraform_create_images/modules/loader_vm/scripts/create_and_load_everything_from_scratch.sh
+++ b/terraform_create_images/modules/loader_vm/scripts/create_and_load_everything_from_scratch.sh
@@ -55,7 +55,6 @@ load_foreach_parquet() {
 load_json_for_elastic() {
   local data_path=$1
   local index=$2
-  local index_file=$3
   echo "[Elasticsearch] Loading $data_path into $index"
   for f in ${data_path}/part-*.json; do
     cat $f | esbulk -0 -server ${ES_HOST}:9200 -index $index -size 2000 -w $(expr $cpu_count / 2)
@@ -116,25 +115,15 @@ halfCPU=$(expr $cpu_count / 2)
 } &
 {
   echo "[Elasticsearch] load studies data"
-  load_json_for_elastic \
-    "${data_path}/search/study" \
-    studies \
-    "${SCRIPT_DIR}/index_settings_studies.json"
-
+  load_json_for_elastic "${data_path}/search/study" studies
 } &
 {
   echo "[Elasticsearch] load genes data"
-  load_json_for_elastic \
-    "${data_path}/search/gene" \
-    genes \
-    "${SCRIPT_DIR}/index_settings_genes.json"
+  load_json_for_elastic "${data_path}/search/gene" genes
 } &
 {
   echo "[Elasticsearch] load variants data"
-  load_json_for_elastic \
-    "${data_path}/search/variant" \
-    variants \
-    "${SCRIPT_DIR}/index_settings_variants.json"
+  load_json_for_elastic "${data_path}/search/variant" variants
 } &
 wait
 

--- a/terraform_create_images/modules/loader_vm/scripts/create_and_load_everything_from_scratch.sh
+++ b/terraform_create_images/modules/loader_vm/scripts/create_and_load_everything_from_scratch.sh
@@ -77,8 +77,6 @@ intermediateTables=(
   v2d_sa_molecular_trait
   l2g
   manhattan
-  v2g_scored
-  d2v2g_scored
 )
 ## Create intermediary tables
 for t in "${intermediateTables[@]}"; do
@@ -102,6 +100,9 @@ quarterCPU=$(expr $cpu_count / 4)
 
 {
   echo "--- D2V2G SCORED START ---"
+
+  echo "[Clickhouse] Creating intermediary table: d2v2g_scored_log"
+  clickhouse-client -h ${CLICKHOUSE_HOST} -m -n <"${SCRIPT_DIR}/clickhouse/sql/d2v2g_scored_log.sql"
 
   echo "[Clickhouse] Loading d2v2g_scored to log table."
   load_foreach_parquet "${data_path}/outputs/d2v2g_scored" "ot.d2v2g_scored_log" $halfCPU
@@ -139,6 +140,8 @@ quarterCPU=$(expr $cpu_count / 4)
 wait
 
 echo "--- V2G SCORED START ---"
+echo "[Clickhouse] Creating intermediary table: v2g_scored_log"
+clickhouse-client -h ${CLICKHOUSE_HOST} -m -n <"${SCRIPT_DIR}/clickhouse/sql/v2g_scored_log.sql"
 echo "[Clickhouse] Loading v2g_scored to log table."
 load_foreach_parquet "${data_path}/outputs/v2g_scored" "ot.v2g_scored_log" $halfCPU
 clickhouse-client -h "${CLICKHOUSE_HOST}" -m -n <"${SCRIPT_DIR}/v2g_scored.sql"

--- a/terraform_create_images/modules/loader_vm/scripts/create_and_load_everything_from_scratch.sh
+++ b/terraform_create_images/modules/loader_vm/scripts/create_and_load_everything_from_scratch.sh
@@ -131,7 +131,7 @@ quarterCPU=$(expr $cpu_count / 4)
     "${SCRIPT_DIR}/index_settings_genes.json"
 } &
 {
-  echo "[Elasticsearch] load genes data"
+  echo "[Elasticsearch] load variants data"
   load_json_for_elastic \
     "${data_path}/search/variant" \
     variants \

--- a/terraform_create_images/modules/loader_vm/scripts/create_and_load_everything_from_scratch.sh
+++ b/terraform_create_images/modules/loader_vm/scripts/create_and_load_everything_from_scratch.sh
@@ -5,6 +5,8 @@
 export ES_HOST="${ES_HOST:-localhost}"
 export CLICKHOUSE_HOST="${CLICKHOUSE_HOST:-localhost}"
 export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+export data_path="${DATA_PATH:-/tmp/data}"
+export cpu_count="${CPU_COUNT:-$(nproc --all)}"
 
 if [ $# -ne 1 ]; then
   echo "Recreates ot database and loads data."
@@ -12,8 +14,6 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 GS_DATA="${1}"
-data_path="/tmp/data"
-cpu_count=$(nproc --all)
 echo "${cpu_count} CPUs available for parallelisation."
 
 gsutil -m cp -r $GS_DATA $data_path &>/dev/null


### PR DESCRIPTION
A few improvements to the data loading script:

- Use `ES_HOST` and `CLICKHOUSE_HOST` variables
- Fix paths to ClickHouse schemas and Elasticseach index settings
- Remove `d2v2g_scored` and `v2g_scored` from intermediate tables
- Enable configuration of `data_path` and `cpu_count`
- Remove hard-coded `outputs` subpath
- Fix log message